### PR TITLE
fix - requiresMainQueueSetup warning on iOS

### DIFF
--- a/ios/FileAccess.swift
+++ b/ios/FileAccess.swift
@@ -2,6 +2,10 @@ import CommonCrypto
 
 @objc(FileAccess)
 class FileAccess: NSObject {
+    @objc static func requiresMainQueueSetup() -> Bool {
+        return true
+    }
+    
     @objc func constantsToExport() -> NSObject {
         return [
             "CacheDir": NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!,


### PR DESCRIPTION
Resolves the warning that the module requires main queue setup because it overrides constantsToExport