### PR TITLE
feat(ios): add resolving Apple based app-groups directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ type FetchResult = {
 `FilesSystem.hash(path: string, algorithm: 'MD5' | 'SHA-1' | 'SHA-224' | 'SHA-256' | 'SHA-384' | 'SHA-512'): Promise<string>`
 - Hash the file content.
 
+`FilesSystem.getAppGroupDir(groupName: string): Promise<string>`
+- Get the directory for your app group (iOS only).
+  - App groups are used on iOS/MacOS for storing content, which is shared between apps.
+  - This is e.g. useful for sharing data between your iOS app and a widget or a watch app.
+
+
 `FilesSystem.isDir(path: string): Promise<boolean>`
 - Check if a path is a directory.
 

--- a/ios/FileAccess.m
+++ b/ios/FileAccess.m
@@ -37,6 +37,10 @@ RCT_EXTERN_METHOD(fetch:(NSString *)resource
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)
 
+RCT_EXTERN_METHOD(getAppGroupDir:(NSString *)groupName
+                 withResolver:(RCTPromiseResolveBlock)resolve
+                 withRejecter:(RCTPromiseRejectBlock)reject)
+
 RCT_EXTERN_METHOD(hash:(NSString *)path withAlgorithm:(NSString *)algorithm
                  withResolver:(RCTPromiseResolveBlock)resolve
                  withRejecter:(RCTPromiseRejectBlock)reject)

--- a/ios/FileAccess.swift
+++ b/ios/FileAccess.swift
@@ -179,6 +179,16 @@ class FileAccess: NSObject {
         downloadTask.resume()
     }
 
+    @objc(getAppGroupDir:withResolver:withRejecter:)
+    func getAppGroupDir(groupName: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
+        guard let groupURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: groupName) else {
+            reject("ERR", "Could not resolve app group directory. The group name '\(groupName)' is invalid.", nil)
+            return
+        }
+
+        resolve(groupURL.path)
+    }
+
     @objc(hash:withAlgorithm:withResolver:withRejecter:)
     func hash(path: String, algorithm: String, resolve: RCTPromiseResolveBlock, reject: RCTPromiseRejectBlock) -> Void {
         guard let data = NSData(contentsOfFile: path) else {

--- a/jest/react-native-file-access.ts
+++ b/jest/react-native-file-access.ts
@@ -1,5 +1,6 @@
 /* global jest */
 
+import { Platform } from 'react-native';
 import type {
   ExternalDir,
   FetchResult,
@@ -102,6 +103,18 @@ class FileSystemMock {
       };
     }
   );
+
+  /**
+   * Return the local storage directory for app groups.
+   *
+   * This is an Apple only feature.
+   */
+  public getAppGroupDir = jest.fn((groupName: string) => {
+    if (Platform.OS !== 'ios' && Platform.OS !== 'macos') {
+      throw new Error('AppGroups are available on Apple devices only');
+    }
+    return `${Dirs.DocumentDir}/shared/AppGroup/${groupName}`;
+  });
 
   /**
    * Hash the file content.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { NativeModules } from 'react-native';
+import { NativeModules, Platform } from 'react-native';
 import { FileAccessNative } from './native';
 import type {
   Encoding,
@@ -90,6 +90,20 @@ export const FileSystem = {
     }
   ): Promise<FetchResult> {
     return FileAccessNative.fetch(resource, init);
+  },
+
+  /**
+   * Return the local storage directory for app groups.
+   *
+   * This is an Apple only feature.
+   */
+  getAppGroupDir(groupName: string) {
+    if (Platform.OS !== 'ios' && Platform.OS !== 'macos') {
+      return Promise.reject(
+        new Error('AppGroups are available on Apple devices only')
+      );
+    }
+    return FileAccessNative.getAppGroupDir(groupName);
   },
 
   /**

--- a/src/native.ts
+++ b/src/native.ts
@@ -29,6 +29,7 @@ type FileAccessType = {
       path?: string;
     }
   ): Promise<FetchResult>;
+  getAppGroupDir(groupName: string): Promise<string>;
   hash(path: string, algorithm: HashAlgorithm): Promise<string>;
   isDir(path: string): Promise<boolean>;
   ls(path: string): Promise<string[]>;


### PR DESCRIPTION
Hello,

I'm currently in the process of getting rid of rn-fetch-blob due to the fact that is is being [unmaintained](https://github.com/joltup/rn-fetch-blob/issues/666) for a while now. I stumbled across `rn-file-access` and like the simplicity and usage of modern languages.

To be able to switch over I need some additional features, starting with being able to resolve Apple's app-group directory for sharing content within an app-group. Please feel free to accept this pull-request.

## Testing done
Since app-groups require a proper entitlement including a signing configuration, I haven't checked in that code in the example app, but will provide a code snippet for doing this.

To be able to test this change, follow those steps

1. add the app-group entitlement in XCode and provide `group.FileAccessExample` as the group name
2. select a proper signing profile to be able to use app-groups
3. add the following code somewhere in `example/src/App.tsx` within the `setInfo` `useEffect`

```js
    // AppGroups on Apple devices
    FileSystem.getAppGroupDir('group.FileAccessExample').then((groupDir) => {
      setInfo((prev) => {
        prev.push({
          key: 'getAppGroupDir(group.FileAccessExample)',
          value: groupDir,
        });

        return prev.slice();
      });
    });
```
 4. this should provide the following content
```txt
getAppGroupDir(group.FileAccessExample) /Users/username/Library/Developer/CoreSimulator/Devices/DEADC0DE-BEEF-C0F3-C0FE-DEADBEEF/data/Containers/Shared/AppGroup/DEADC0DE-BEEF-C0F3-C0FE-DEADBEEF
```

Thanks,
Martin