### PR TITLE
Change Android Base64 mode to omit line breaks

### DIFF
--- a/android/src/main/java/com/alpha0010/fs/FileAccessModule.kt
+++ b/android/src/main/java/com/alpha0010/fs/FileAccessModule.kt
@@ -301,7 +301,7 @@ class FileAccessModule(reactContext: ReactApplicationContext) :
     try {
       val data = openForReading(path).use { it.readBytes() }
       if (encoding == "base64") {
-        promise.resolve(Base64.encodeToString(data, Base64.DEFAULT))
+        promise.resolve(Base64.encodeToString(data, Base64.NO_WRAP))
       } else {
         promise.resolve(data.decodeToString())
       }


### PR DESCRIPTION
This is mostly a suggestion: the DEFAULT options of Base64.encodeString() adds line breaks to wrap the output to 80 (or something like that) characters. The iOS base64 encoder does *not* do this, making the Android and iOS output of readFile(..., 'base64') different. I believe this change would make them the same. (Additionally, a lot of base64 decoders, reasonably or not, do not seem to correctly handle the line breaks. I had to strip them out manually to use as input for pdf-lib, e.g..