### PR TITLE
fix: writeFile base64string failed

### DIFF
--- a/ios/FileAccess.swift
+++ b/ios/FileAccess.swift
@@ -329,7 +329,7 @@ class FileAccess: RCTEventEmitter {
             do {
                 if encoding == "base64" {
                     let pathUrl = URL(fileURLWithPath: path.path())
-                    guard let decoded = Data(base64Encoded: data) else {
+                    guard let decoded = Data(base64Encoded: data, options: .ignoreUnknownCharacters) else {
                         reject("ERR", "Failed to write to '\(path)', invalid base64.", nil)
                         return
                     }


### PR DESCRIPTION
when base64 too long will add \r\n 

so we need ignoreunknowncharacters
https://developer.apple.com/documentation/foundation/nsdata/base64decodingoptions/1410087-ignoreunknowncharacters