### PR TITLE
feat: allow reading chunks from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,11 @@ type ManagedFetchResult = {
 - Read the content of a file.
   - Default encoding of returned string is utf8.
 
+`FileSystem.readFileChunk(path: string, offset: number, length: number, encoding?: 'utf8' | 'base64'): Promise<string>`
+
+- Read a chunk of the content of a file, starting from byte at `offset`, reading for `length` bytes.
+  - Default encoding of returned string is utf8.
+
 ```
 FileSystem.stat(path: string): Promise<FileStat>
 

--- a/android/src/main/java/com/alpha0010/fs/FileAccessModule.kt
+++ b/android/src/main/java/com/alpha0010/fs/FileAccessModule.kt
@@ -401,6 +401,26 @@ class FileAccessModule internal constructor(context: ReactApplicationContext) :
   }
 
   @ReactMethod
+  override fun readFileChunk(path: String, offset: Double, length: Double, encoding: String, promise: Promise) {
+    ioScope.launch {
+      try {
+        val inputStream = openForReading(path);
+        inputStream.skip(offset.toLong())
+        val data = ByteArray(length.toInt())
+        inputStream.read(data);
+
+        if (encoding == "base64") {
+          promise.resolve(Base64.encodeToString(data, Base64.NO_WRAP))
+        } else {
+          promise.resolve(data.decodeToString())
+        }
+      } catch (e: Throwable) {
+        promise.reject(e)
+      }
+    }
+  }
+
+  @ReactMethod
   override fun stat(path: String, promise: Promise) {
     ioScope.launch {
       try {

--- a/android/src/oldarch/FileAccessSpec.kt
+++ b/android/src/oldarch/FileAccessSpec.kt
@@ -30,6 +30,7 @@ abstract class FileAccessSpec internal constructor(context: ReactApplicationCont
   abstract fun mkdir(path: String, promise: Promise)
   abstract fun mv(source: String, target: String, promise: Promise)
   abstract fun readFile(path: String, encoding: String, promise: Promise)
+  abstract fun readFileChunk(path: String, offset: Double, length: Double, encoding: String, promise: Promise)
   abstract fun stat(path: String, promise: Promise)
   abstract fun statDir(path: String, promise: Promise)
   abstract fun unlink(path: String, promise: Promise)

--- a/ios/FileAccess.mm
+++ b/ios/FileAccess.mm
@@ -22,6 +22,7 @@
 - (void)mkdir:(NSString * _Nonnull)path withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (void)mv:(NSString * _Nonnull)source withTarget:(NSString * _Nonnull)target withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (void)readFile:(NSString * _Nonnull)path withEncoding:(NSString * _Nonnull)encoding withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
+- (void)readFileChunk:(NSString * _Nonnull)path withOffset:(NSNumber * _Nonnull)offset withLength:(NSNumber * _Nonnull)length withEncoding:(NSString * _Nonnull)encoding withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (void)stat:(NSString * _Nonnull)path withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (void)statDir:(NSString * _Nonnull)path withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
 - (void)unlink:(NSString * _Nonnull)path withResolver:(RCTPromiseResolveBlock _Nonnull)resolve withRejecter:(RCTPromiseRejectBlock _Nonnull)reject;
@@ -169,6 +170,19 @@ RCT_EXPORT_METHOD(readFile:(NSString *)path
 {
     [impl readFile:path withEncoding:encoding withResolver:resolve withRejecter:reject];
 }
+
+RCT_EXPORT_METHOD(readFileChunk:(NSString *)path
+                  offset:(double)offset
+                  length:(double)length
+                  encoding:(NSString *)encoding
+                  resolve:(RCTPromiseResolveBlock)resolve
+                  reject:(RCTPromiseRejectBlock)reject)
+{
+    NSNumber *offsetNumber = @(offset);
+    NSNumber *lengthNumber = @(length);
+    [impl readFileChunk:path withOffset:offsetNumber withLength:lengthNumber withEncoding:encoding withResolver:resolve withRejecter:reject];
+}
+
 
 RCT_EXPORT_METHOD(stat:(NSString *)path
                   resolve:(RCTPromiseResolveBlock)resolve

--- a/src/NativeFileAccess.ts
+++ b/src/NativeFileAccess.ts
@@ -71,7 +71,12 @@ export interface Spec extends TurboModule {
   mkdir(path: string): Promise<string>;
   mv(source: string, target: string): Promise<void>;
   readFile(path: string, encoding: string): Promise<string>;
-  readFileChunk(path: string, offset: number, length: number, encoding: string): Promise<string>;
+  readFileChunk(
+    path: string,
+    offset: number,
+    length: number,
+    encoding: string
+  ): Promise<string>;
   stat(path: string): Promise<FileStat>;
   statDir(path: string): Promise<FileStat[]>;
   unlink(path: string): Promise<void>;

--- a/src/NativeFileAccess.ts
+++ b/src/NativeFileAccess.ts
@@ -71,6 +71,7 @@ export interface Spec extends TurboModule {
   mkdir(path: string): Promise<string>;
   mv(source: string, target: string): Promise<void>;
   readFile(path: string, encoding: string): Promise<string>;
+  readFileChunk(path: string, offset: number, length: number, encoding: string): Promise<string>;
   stat(path: string): Promise<FileStat>;
   statDir(path: string): Promise<FileStat[]>;
   unlink(path: string): Promise<void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,7 +278,12 @@ export const FileSystem = {
   /**
    * Read a chunk of the content of a file.
    */
-  readFileChunk(path: string, offset: number, length: number, encoding: Encoding = 'utf8') {
+  readFileChunk(
+    path: string,
+    offset: number,
+    length: number,
+    encoding: Encoding = 'utf8'
+  ) {
     return FileAccessNative.readFileChunk(path, offset, length, encoding);
   },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,6 +276,13 @@ export const FileSystem = {
   },
 
   /**
+   * Read a chunk of the content of a file.
+   */
+  readFileChunk(path: string, offset: number, length: number, encoding: Encoding = 'utf8') {
+    return FileAccessNative.readFileChunk(path, offset, length, encoding);
+  },
+
+  /**
    * Read file metadata.
    */
   stat(path: string): Promise<FileStat> {


### PR DESCRIPTION
Allow reading chunks from files, starting with the byte at `offset` index, reading for `length` bytes.

Like this it is possible to e.g. upload file chunks to a server.

This change will also allow people who are still using [react-native-fs](https://github.com/itinance/react-native-fs) only because of this feature, to migrate to [react-native-file-access](https://github.com/alpha0010/react-native-file-access).