### PR TITLE
fix iOS link error causing issue to link in podFile while installed from npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ API 30 or higher.
 npm install react-native-file-access
 cd ios && pod install
 ```
-
+``` Note:
+issue with iOS Linking:
+  if iOS is unable to link automatically got to you ios podFile and add this:
+    pod 'react-native-file-access', :path => '<Location_to_your_node_modules>/node_modules/react-native-file-access'
+```
 Apple restricts usage of certain privacy sensitive API calls. If you do not
 use disk space measurements or file timestamps, define the following variable
 in your Podfile to exclude restricted API calls.

--- a/react-native-file-access.podspec
+++ b/react-native-file-access.podspec
@@ -4,7 +4,7 @@ package = JSON.parse(File.read(File.join(__dir__, "package.json")))
 folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
 Pod::Spec.new do |s|
-  s.name         = "ReactNativeFileAccess"
+  s.name         = "react-native-file-access"
   s.version      = package["version"]
   s.summary      = package["description"]
   s.homepage     = package["homepage"]


### PR DESCRIPTION
Hey @alpha0010, I found this error causing issue to link with iOS manually on debugging found this issue:
``` Unable to link iOS on debugging found that we're not using exact name as package causing podspec error in react native file access being getting unlinked ```
can you please merge so that it will be easy for users to use this package specifically in RN 73


<img width="612" alt="Screenshot 2024-07-29 at 10 43 38 AM" src="https://github.com/user-attachments/assets/fe0ae68a-4b7f-447d-bca9-b1f58363015c">
PS: Also all my node modules are in the same directory so folks please ignore the node modules path

Thanks in advance for this package.