### PR TITLE
fix(ios): use `install_modules_dependencies` in podspec file

### DIFF
--- a/ReactNativeFileAccess.podspec
+++ b/ReactNativeFileAccess.podspec
@@ -28,16 +28,6 @@ Pod::Spec.new do |s|
 
   # Don't install the dependencies when we run `pod install` in the old architecture.
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
-    s.compiler_flags = folly_compiler_flags + " -DRCT_NEW_ARCH_ENABLED=1"
-    s.pod_target_xcconfig    = {
-        "HEADER_SEARCH_PATHS" => "\"$(PODS_ROOT)/boost\"",
-        "OTHER_CPLUSPLUSFLAGS" => "-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1",
-        "CLANG_CXX_LANGUAGE_STANDARD" => "c++17"
-    }
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
+    install_modules_dependencies(s)
   end
 end


### PR DESCRIPTION
### Bug

In React Native 0.75, with New Architecture enabled, iOS builds fail with the following error:
```
ios/build/generated/ios/RNFileAccessSpec/RNFileAccessSpec.h:29:9: 
fatal error: 'ReactCommon/RCTTurboModule.h' file not found
#import <ReactCommon/RCTTurboModule.h>
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### To reproduce

1. create a React Native 0.75 project with `npx @react-native-community/cli init`
2. install react-native-file-access: `npm install react-native-file-access`
3. install pods with New Architecture enabled: `cd ios && bundle install && RCT_NEW_ARCH_ENABLED=1 pod install`
4. build for iOS: `npm run ios`

### Details

It looks like some React Native internals have changed in v0.75 and `react-native-file-access` is no longer pulling in the correct dependencies for Turbo Modules.

This PR fixes the issue by updating the podspec file to use `install_modules_dependencies` to install the extra dependencies required for the New Architecture instead of declaring dependencies explicitly. 

This is the recommended approach as per the [React Native docs](https://github.com/reactwg/react-native-new-architecture/blob/main/docs/backwards-compat-turbo-modules.md#dependencies).

### Testing

I've tested this against the following React Native versions to confirm that the fix is backwards compatible:
- 0.75
- 0.72 (using the example app)
- 0.71

Thanks!